### PR TITLE
[R4R]update doc to guide correct dependency

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,24 +16,13 @@ It includes the following core components:
 
 Add "github.com/binance-chain/go-sdk" dependency into your go.mod file. Example:
 ```go
-require (
-	github.com/binance-chain/go-sdk latest
-)
+require github.com/binance-chain/go-sdk v0.9.1
+
+replace github.com/tendermint/go-amino => github.com/binance-chain/bnc-go-amino v0.14.1-binance.1
 ```
 
-### Use go get
-
-Use go get to install sdk into your `GOPATH`:
-```bash
-go get github.com/binance-chain/go-sdk
-```
-
-### Use dep
-Add dependency to your Gopkg.toml file. Example:
-```bash
-[[override]]
-  name = "github.com/binance-chain/go-sdk"
-```
+**Notice**: The amino version depends on the go-sdk release you want to use. You may visit `https://github.com/binance-chain/go-sdk/blob/{release version}/go.mod`
+to find out the correct bnc-go-amino version.
 
 ## Usage 
 


### PR DESCRIPTION
### Description

to resolve `CreateOrder failed: signature verification failed `, related to https://github.com/binance-chain/go-sdk/issues/12

### Rationale

user use go module to add our dependency, however the go-amino use tendermint org not binance.

And go module is the only dependency tool we recommend.

More dependency tool will add in the future https://github.com/binance-chain/go-sdk/issues/14
### Changes

Update doc to notice user.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#12  

