### PR TITLE
base asset symbol can have a length of 9 / change dependency to bnc-go-amino fix for issue #15

### DIFF
--- a/common/crypto/encoding/amino/amino.go
+++ b/common/crypto/encoding/amino/amino.go
@@ -1,7 +1,7 @@
 package cryptoAmino
 
 import (
-	"github.com/tendermint/go-amino"
+	"github.com/binance-chain/bnc-go-amino"
 
 	"github.com/binance-chain/go-sdk/common/crypto"
 	"github.com/binance-chain/go-sdk/common/crypto/secp256k1"

--- a/common/crypto/secp256k1/secp256k1.go
+++ b/common/crypto/secp256k1/secp256k1.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	secp256k1 "github.com/tendermint/btcd/btcec"
-	"github.com/tendermint/go-amino"
+	"github.com/binance-chain/bnc-go-amino"
 	"golang.org/x/crypto/ripemd160"
 
 	"github.com/binance-chain/go-sdk/common/crypto"

--- a/types/msg/msg-gov.go
+++ b/types/msg/msg-gov.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tendermint/go-amino"
+	"github.com/binance-chain/bnc-go-amino"
 )
 
 // name to idetify transaction types

--- a/types/msg/msg.go
+++ b/types/msg/msg.go
@@ -2,8 +2,9 @@ package msg
 
 import (
 	"fmt"
-	"github.com/binance-chain/go-sdk/types"
 	"strings"
+
+	"github.com/binance-chain/go-sdk/types"
 )
 
 // constants
@@ -47,7 +48,7 @@ func ValidateSymbol(symbol string) error {
 		return fmt.Errorf("Token symbol cannot be empty")
 	}
 
-	if len(symbol) > 8 {
+	if len(symbol) > 9 {
 		return fmt.Errorf("Token symbol is too long")
 	}
 

--- a/types/msg/wire.go
+++ b/types/msg/wire.go
@@ -1,7 +1,7 @@
 package msg
 
 import (
-	"github.com/tendermint/go-amino"
+	"github.com/binance-chain/bnc-go-amino"
 
 	"github.com/binance-chain/go-sdk/common/crypto/encoding/amino"
 )

--- a/types/tx/wire.go
+++ b/types/tx/wire.go
@@ -1,7 +1,7 @@
 package tx
 
 import (
-	"github.com/tendermint/go-amino"
+	"github.com/binance-chain/bnc-go-amino"
 
 	"github.com/binance-chain/go-sdk/types/msg"
 )


### PR DESCRIPTION
I am not sure whether this is against the spec, but i just listed `TESLA-A4F`. 


> Symbol: identifier of the token, limited to 8 alphanumeric characters and is case insensitive, for example, "BNB". ".B" suffixed symbol is also allowed for migrating these tokens already exist on other chains. The symbol do not need to be unique, a random 3 letters would be appended, after a "-", to the provided symbol to avoid uniqueness constraint. for example, "NNB-B90". Only BNB does not have this suffix.

https://binance-chain.github.io/tokens.html#issue

Second part fixes dependency issue #15 