### PR TITLE
[R4R]change source into 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## latest
+IMPROVEMENTS
+* [\#53](https://github.com/binance-chain/go-sdk/pull/53) [SOURCE] change the default source into 0

--- a/types/config.go
+++ b/types/config.go
@@ -6,6 +6,4 @@ const (
 	DefaultAPIVersionPrefix = "/api/v1"
 	DefaultWSPrefix         = "/api/ws"
 	NativeSymbol            = "BNB"
-
-	GoSdkSource = 2
 )

--- a/types/tx/stdtx.go
+++ b/types/tx/stdtx.go
@@ -6,7 +6,7 @@ import (
 	"github.com/tendermint/tendermint/libs/common"
 )
 
-const Source int64 = 2
+const Source int64 = 0
 
 type Tx interface {
 


### PR DESCRIPTION
According to our source definition https://docs.google.com/spreadsheets/d/1oCYDrXNB_u4OBusDHEbG6G_-qqerdedAcacLz7f8LK4/edit#gid=1480376460
The go-sdk shoud use 0 as default source value. 