### PR TITLE
[R4R]add reconnect strategy when timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## latest
 IMPROVEMENTS
 * [\#53](https://github.com/binance-chain/go-sdk/pull/53) [SOURCE] change the default source into 0
+* [\#56](https://github.com/binance-chain/go-sdk/pull/56) [RPC] add reconnect strategy when timeout to receive response

--- a/client/rpc/ws_client.go
+++ b/client/rpc/ws_client.go
@@ -236,6 +236,7 @@ func (w *WSEvents) WaitForResponse(ctx context.Context, outChan chan rpctypes.RP
 		}
 		return w.cdc.UnmarshalJSON(resp.Result, result)
 	case <-ctx.Done():
+		w.ws.reconnectAfter <- ctx.Err()
 		return ctx.Err()
 	}
 }
@@ -649,6 +650,9 @@ func (c *WSClient) GetConnection() *websocket.Conn {
 func (c *WSClient) SetConnection(conn *websocket.Conn) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+	if c.conn != nil {
+		c.conn.Close()
+	}
 	c.conn = conn
 }
 


### PR DESCRIPTION
For now only the read or write operation of websocket connection failed will trigger reconnection.
Sometimes the server misbehaves, and client can't receive response intime, should try to disconnect and dial again.