### PR TITLE
[R4R] support bip44 to derive many address from same seed phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 IMPROVEMENTS
 * [\#53](https://github.com/binance-chain/go-sdk/pull/53) [SOURCE] change the default source into 0
 * [\#56](https://github.com/binance-chain/go-sdk/pull/56) [RPC] add reconnect strategy when timeout to receive response
+* [\#61](https://github.com/binance-chain/go-sdk/pull/61) [KEY] support bip44 to derive many address from same seed phase
 
 ## BREAKING
 * [\#57](https://github.com/binance-chain/go-sdk/pull/57) [API] add query option to getTokens api

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,6 +53,8 @@ NewKeyManager() (KeyManager, error)
 
 NewMnemonicKeyManager(mnemonic string) (KeyManager, error)
 
+NewMnemonicPathKeyManager(mnemonic, keyPath string) (KeyManager, error) 
+
 NewKeyStoreKeyManager(file string, auth string) (KeyManager, error)
 
 NewPrivateKeyManager(priKey string) (KeyManager, error) 
@@ -62,6 +64,7 @@ NewLedgerKeyManager(path ledger.DerivationPath) (KeyManager, error)
 ```
 - NewKeyManager. You will get a new private key without provide anything, you can export and save this `KeyManager`.
 - NewMnemonicKeyManager. You should provide your mnemonic, usually is a string of 24 words.
+- NewMnemonicPathKeyManager. The difference between `NewMnemonicKeyManager` is that you can use custom keypath to generate different `keyManager` while using the same mnemonic. 5 levels in BIP44 path: "purpose' / coin_type' / account' / change / address_index", "purpose' / coin_type'" is fixed as "44'/714'/", you can customize the rest part. 
 - NewKeyStoreKeyManager. You should provide a keybase json file and you password, you can download the key base json file when your create a wallet account.
 - NewPrivateKeyManager. You should provide a Hex encoded string of your private key.
 - NewLedgerKeyManager. You must have a ledger device with binance ledger app and connect it to your machine.

--- a/keys/hdpath.go
+++ b/keys/hdpath.go
@@ -15,12 +15,12 @@ import (
 
 // BIP44Prefix is the parts of the BIP32 HD path that are fixed by what we used during the fundraiser.
 const (
-	BIPPurpose         = 44
-	BIPCoinType        = 714
-	BIPChange          = false
-	BIP44Prefix        = "44'/714'/"
-	PartialFundraiserPath = "0'/0/0"
-	FullFundraiserPath = BIP44Prefix + PartialFundraiserPath
+	BIPPurpose  = 44
+	BIPCoinType = 714
+	BIPChange   = false
+	BIP44Prefix = "44'/714'/"
+	PartialPath = "0'/0/0"
+	FullPath    = BIP44Prefix + PartialPath
 )
 
 // BIP44Params wraps BIP 44 params (5 level BIP 32 path).

--- a/keys/hdpath.go
+++ b/keys/hdpath.go
@@ -19,7 +19,8 @@ const (
 	BIPCoinType        = 714
 	BIPChange          = false
 	BIP44Prefix        = "44'/714'/"
-	FullFundraiserPath = BIP44Prefix + "0'/0/0"
+	PartialFundraiserPath = "0'/0/0"
+	FullFundraiserPath = BIP44Prefix + PartialFundraiserPath
 )
 
 // BIP44Params wraps BIP 44 params (5 level BIP 32 path).

--- a/keys/hdpath.go
+++ b/keys/hdpath.go
@@ -13,7 +13,6 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 )
 
-// BIP44Prefix is the parts of the BIP32 HD path that are fixed by what we used during the fundraiser.
 const (
 	BIPPurpose  = 44
 	BIPCoinType = 714
@@ -47,28 +46,6 @@ func NewParams(purpose, coinType, account uint32, change bool, addressIdx uint32
 	}
 }
 
-func hardenedInt(field string) (uint32, error) {
-	field = strings.TrimSuffix(field, "'")
-	i, err := strconv.Atoi(field)
-	if err != nil {
-		return 0, err
-	}
-	if i < 0 {
-		return 0, fmt.Errorf("fields must not be negative. got %d", i)
-	}
-	return uint32(i), nil
-}
-
-func isHardened(field string) bool {
-	return strings.HasSuffix(field, "'")
-}
-
-// NewFundraiserParams creates a BIP 44 parameter object from the params:
-// m / 44' / 714' / account' / 0 / address_index
-// The fixed parameters (purpose', coin_type', and change) are determined by what was used in the fundraiser.
-func NewFundraiserParams(account uint32, addressIdx uint32) *BIP44Params {
-	return NewParams(BIPPurpose, BIPCoinType, account, BIPChange, addressIdx)
-}
 
 // NewBinanceBIP44Params creates a BIP 44 parameter object from the params:
 // m / 44' / 714' / account' / 0 / address_index

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -39,7 +39,15 @@ type KeyManager interface {
 
 func NewMnemonicKeyManager(mnemonic string) (KeyManager, error) {
 	k := keyManager{}
-	err := k.recoveryFromKMnemonic(mnemonic)
+	err := k.recoveryFromMnemonic(mnemonic, FullFundraiserPath)
+	return &k, err
+}
+
+// The full fundraiser path is  "purpose' / coin_type' / account' / change / address_index".
+// "purpose' / coin_type'" is fixed as "44'/714'/", user can customize the rest part.
+func NewMnemonicPathKeyManager(mnemonic, keyPath string) (KeyManager, error) {
+	k := keyManager{}
+	err := k.recoveryFromMnemonic(mnemonic, BIP44Prefix+keyPath)
 	return &k, err
 }
 
@@ -98,7 +106,7 @@ func NewKeyManager() (KeyManager, error) {
 	return NewMnemonicKeyManager(mnemonic)
 }
 
-func (m *keyManager) recoveryFromKMnemonic(mnemonic string) error {
+func (m *keyManager) recoveryFromMnemonic(mnemonic, keyPath string) error {
 	words := strings.Split(mnemonic, " ")
 	if len(words) != 12 && len(words) != 24 {
 		return fmt.Errorf("mnemonic length should either be 12 or 24")
@@ -109,7 +117,7 @@ func (m *keyManager) recoveryFromKMnemonic(mnemonic string) error {
 	}
 	// create master key and derive first key:
 	masterPriv, ch := ComputeMastersFromSeed(seed)
-	derivedPriv, err := DerivePrivateKeyForPath(masterPriv, ch, FullFundraiserPath)
+	derivedPriv, err := DerivePrivateKeyForPath(masterPriv, ch, keyPath)
 	if err != nil {
 		return err
 	}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -43,7 +43,7 @@ func NewMnemonicKeyManager(mnemonic string) (KeyManager, error) {
 	return &k, err
 }
 
-// The full fundraiser path is  "purpose' / coin_type' / account' / change / address_index".
+// The full path is  "purpose' / coin_type' / account' / change / address_index".
 // "purpose' / coin_type'" is fixed as "44'/714'/", user can customize the rest part.
 func NewMnemonicPathKeyManager(mnemonic, keyPath string) (KeyManager, error) {
 	k := keyManager{}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -39,7 +39,7 @@ type KeyManager interface {
 
 func NewMnemonicKeyManager(mnemonic string) (KeyManager, error) {
 	k := keyManager{}
-	err := k.recoveryFromMnemonic(mnemonic, FullFundraiserPath)
+	err := k.recoveryFromMnemonic(mnemonic, FullPath)
 	return &k, err
 }
 

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -21,12 +21,11 @@ func TestRecoveryFromKeyWordsNoError(t *testing.T) {
 	assert.NoError(t, err)
 	acc := keyManger.GetAddr()
 	key := keyManger.GetPrivKey()
-	if acc.String() != "bnb1ddt3ls9fjcd8mh69ujdg3fxc89qle2a7km33aa" {
-		t.Fatalf("RecoveryFromKeyWords get unstable account")
-	}
-	if key == nil {
-		t.Fatalf("Failed to recover private key")
-	}
+	assert.Equal(t,"bnb1ddt3ls9fjcd8mh69ujdg3fxc89qle2a7km33aa",acc.String())
+	assert.NotNil(t,key)
+	customPathKey, err:= NewMnemonicPathKeyManager(mnemonic,"1'/1/1")
+	assert.NoError(t, err)
+	assert.Equal(t,"bnb1c67nwp7u5adl7gw0ffn3d47kttcm4crjy9mrye",customPathKey.GetAddr().String())
 }
 
 func TestRecoveryFromKeyBaseNoError(t *testing.T) {


### PR DESCRIPTION
resolve https://github.com/binance-chain/go-sdk/issues/59.

For now, the keymanager is generated from the default path:  "44'/714'/0'/0/0"
The 5 level path is : "purpose' / coin_type' / account' / change / address_index"
The " account' / change / address_index" part can be custom.
