### PR TITLE
[R4R]fix Unmarshal result of async transaction

### DIFF
--- a/client/transaction/create_order.go
+++ b/client/transaction/create_order.go
@@ -35,9 +35,11 @@ func (c *client) CreateOrder(baseAssetSymbol, quoteAssetSymbol string, op int8, 
 		OrderId string `json:"order_id"`
 	}
 	var cdata commitData
-	err = json.Unmarshal([]byte(commit.Data), &cdata)
-	if err != nil {
-		return nil, err
+	if sync {
+		err = json.Unmarshal([]byte(commit.Data), &cdata)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &CreateOrderResult{*commit, cdata.OrderId}, nil


### PR DESCRIPTION
resolve  https://github.com/binance-chain/go-sdk/issues/67.

Only when use "sync" mode, there is order_id response.