### PR TITLE
[R4R]refactor reconnection

### DIFF
--- a/client/rpc/basic_client.go
+++ b/client/rpc/basic_client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/binance-chain/go-sdk/types/tx"
 )
 
-const defaultTimeout = 5 * time.Second
+const defaultTimeout = 2 * time.Second
 
 type Client interface {
 	cmn.Service


### PR DESCRIPTION
### Description
resolve #issue https://github.com/binance-chain/go-sdk/issues/83
To solve the reconnection failed when the network joggle in a sudden

### Rationale
The issue is caused by `readroutine` and `writeroutine` working on different `connection`.

There could be a potential bug if still use state translate in `WsClient`.  So decide to refactor the reconnection code, and new a  WsClient and start it when needed.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed 
- [x]  e2e tests passed
### Already reviewed by

...

### Related issues
https://github.com/binance-chain/go-sdk/issues/83

