### PR TITLE
[R4R] distinguish not found error for get timelock rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 IMPROVEMENT
-* [\#87](https://github.com/binance-chain/go-sdk/pull/87) [RPC] extract error log from rpc response
+* [\#87](https://github.com/binance-chain/go-sdk/pull/87) [RPC] distinguish not found error for get timelock rpc
 * [\#84](https://github.com/binance-chain/go-sdk/pull/84) [RPC] change interface of get timelock
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## latest
 IMPROVEMENT
+* [\#87](https://github.com/binance-chain/go-sdk/pull/87) [RPC] extract error log from rpc response
 * [\#84](https://github.com/binance-chain/go-sdk/pull/84) [RPC] change interface of get timelock
+
 
 ## v1.1.0
 IMPROVEMENT

--- a/client/rpc/ws_client.go
+++ b/client/rpc/ws_client.go
@@ -303,7 +303,12 @@ func (w *WSEvents) ABCIQueryWithOptions(path string, data cmn.HexBytes, opts cli
 	err := w.SimpleCall(func(ctx context.Context, id rpctypes.JSONRPCStringID) error {
 		return wsClient.ABCIQueryWithOptions(ctx, id, path, data, opts)
 	}, wsClient, abciQuery)
-	return abciQuery, err
+	if err != nil {
+		return nil, err
+	} else if abciQuery != nil && abciQuery.Response.IsErr() {
+		return nil, fmt.Errorf("%s, code: %d", abciQuery.Response.Log, abciQuery.Response.Code)
+	}
+	return abciQuery, nil
 }
 
 func (w *WSEvents) BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {

--- a/client/rpc/ws_client.go
+++ b/client/rpc/ws_client.go
@@ -303,12 +303,7 @@ func (w *WSEvents) ABCIQueryWithOptions(path string, data cmn.HexBytes, opts cli
 	err := w.SimpleCall(func(ctx context.Context, id rpctypes.JSONRPCStringID) error {
 		return wsClient.ABCIQueryWithOptions(ctx, id, path, data, opts)
 	}, wsClient, abciQuery)
-	if err != nil {
-		return nil, err
-	} else if abciQuery != nil && abciQuery.Response.IsErr() {
-		return nil, fmt.Errorf("%s, code: %d", abciQuery.Response.Log, abciQuery.Response.Code)
-	}
-	return abciQuery, nil
+	return abciQuery, err
 }
 
 func (w *WSEvents) BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {

--- a/e2e/e2e_rpc_test.go
+++ b/e2e/e2e_rpc_test.go
@@ -71,7 +71,9 @@ func TestRPCGetProposals(t *testing.T) {
 }
 func TestRPCGetTimelocks(t *testing.T) {
 	c := defaultClient()
-	records, err := c.GetTimelocks(testAddress)
+	acc, err := ctypes.AccAddressFromBech32(testAddress)
+	assert.NoError(t, err)
+	records, err := c.GetTimelocks(acc)
 	assert.NoError(t, err)
 	fmt.Println(len(records))
 	for _, record := range records {
@@ -81,7 +83,9 @@ func TestRPCGetTimelocks(t *testing.T) {
 
 func TestRPCGetTimelock(t *testing.T) {
 	c := defaultClient()
-	record, err := c.GetTimelock(testAddress, 1)
+	acc, err := ctypes.AccAddressFromBech32(testAddress)
+	assert.NoError(t, err)
+	record, err := c.GetTimelock(acc, 1)
 	assert.NoError(t, err)
 	fmt.Println(record)
 


### PR DESCRIPTION
We consider if the timelock do not exist, should not return error, just return nil object is fine