### PR TITLE
[R4R]change the default timeout of RPC client as 5 second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## latest
+* [\#103](https://github.com/binance-chain/go-sdk/pull/103) [RPC] change the default timeout of RPC client as 5 seconds
+* [\#102](https://github.com/binance-chain/go-sdk/pull/102) [FIX] Some typos only (managr/manger) 
+
+## 1.2.1
+* [\#99](https://github.com/binance-chain/go-sdk/pull/99) [BUILD] upgrade version of btcd to avoid retag issue 
+
 ## v1.2.0
 * [\#93](https://github.com/binance-chain/go-sdk/pull/93) [BREAKING] uprade to binance chain release 0.6.3
 

--- a/client/rpc/basic_client.go
+++ b/client/rpc/basic_client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/binance-chain/go-sdk/types/tx"
 )
 
-var DefaultTimeout = 2 * time.Second
+var DefaultTimeout = 5 * time.Second
 
 type ABCIClient interface {
 	// Reading from abci app


### PR DESCRIPTION
The default timeout of RPC client is 2 second, we consider it too low, and raise it to 5 seconds.