### PR TITLE
[R4R]fix nil point error in getBalance rpc call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-## latest
+## 1.2.2
+* [\#106](https://github.com/binance-chain/go-sdk/pull/106) [RPC] fix nil point error in getBalance rpc call
 * [\#103](https://github.com/binance-chain/go-sdk/pull/103) [RPC] change the default timeout of RPC client as 5 seconds
 * [\#102](https://github.com/binance-chain/go-sdk/pull/102) [FIX] Some typos only (managr/manger) 
 

--- a/client/rpc/dex_client.go
+++ b/client/rpc/dex_client.go
@@ -82,7 +82,7 @@ func (c *HTTP) ListAllTokens(offset int, limit int) ([]types.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !result.Response.IsOK(){
+	if !result.Response.IsOK() {
 		return nil, fmt.Errorf(result.Response.Log)
 	}
 	bz := result.Response.GetValue()
@@ -100,7 +100,7 @@ func (c *HTTP) GetTokenInfo(symbol string) (*types.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !result.Response.IsOK(){
+	if !result.Response.IsOK() {
 		return nil, fmt.Errorf(result.Response.Log)
 	}
 	bz := result.Response.GetValue()
@@ -165,6 +165,9 @@ func (c *HTTP) GetBalances(addr types.AccAddress) ([]types.TokenBalance, error) 
 	if err != nil {
 		return nil, err
 	}
+	if account == nil {
+		return []types.TokenBalance{}, nil
+	}
 	coins := account.GetCoins()
 
 	symbs := make([]string, 0, len(coins))
@@ -200,6 +203,14 @@ func (c *HTTP) GetBalance(addr types.AccAddress, symbol string) (*types.TokenBal
 	if err != nil {
 		return nil, err
 	}
+	if acc == nil {
+		return &types.TokenBalance{
+			Symbol: symbol,
+			Free:   types.Fixed8Zero,
+			Locked: types.Fixed8Zero,
+			Frozen: types.Fixed8Zero,
+		}, nil
+	}
 	var locked, frozen int64
 	nacc := acc.(types.NamedAccount)
 	if nacc != nil {
@@ -219,7 +230,7 @@ func (c *HTTP) GetFee() ([]types.FeeParam, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !rawFee.Response.IsOK(){
+	if !rawFee.Response.IsOK() {
 		return nil, fmt.Errorf(rawFee.Response.Log)
 	}
 	var fees []types.FeeParam
@@ -235,7 +246,7 @@ func (c *HTTP) GetOpenOrders(addr types.AccAddress, pair string) ([]types.OpenOr
 	if err != nil {
 		return nil, err
 	}
-	if !rawOrders.Response.IsOK(){
+	if !rawOrders.Response.IsOK() {
 		return nil, fmt.Errorf(rawOrders.Response.Log)
 	}
 	bz := rawOrders.Response.GetValue()
@@ -261,7 +272,7 @@ func (c *HTTP) GetTradingPairs(offset int, limit int) ([]types.TradingPair, erro
 	if err != nil {
 		return nil, err
 	}
-	if !rawTradePairs.Response.IsOK(){
+	if !rawTradePairs.Response.IsOK() {
 		return nil, fmt.Errorf(rawTradePairs.Response.Log)
 	}
 	pairs := make([]types.TradingPair, 0)
@@ -283,7 +294,7 @@ func (c *HTTP) GetDepth(tradePair string, level int) (*types.OrderBook, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !rawDepth.Response.IsOK(){
+	if !rawDepth.Response.IsOK() {
 		return nil, fmt.Errorf(rawDepth.Response.Log)
 	}
 	var ob types.OrderBook
@@ -314,7 +325,7 @@ func (c *HTTP) GetTimelocks(addr types.AccAddress) ([]types.TimeLockRecord, erro
 	if rawRecords == nil {
 		return nil, fmt.Errorf("zero records")
 	}
-	if !rawRecords.Response.IsOK(){
+	if !rawRecords.Response.IsOK() {
 		return nil, fmt.Errorf(rawRecords.Response.Log)
 	}
 	records := make([]types.TimeLockRecord, 0)
@@ -376,7 +387,7 @@ func (c *HTTP) GetProposals(status types.ProposalStatus, numLatest int64) ([]typ
 	if err != nil {
 		return nil, err
 	}
-	if !rawProposals.Response.IsOK(){
+	if !rawProposals.Response.IsOK() {
 		return nil, fmt.Errorf(rawProposals.Response.Log)
 	}
 	proposals := make([]types.Proposal, 0)
@@ -397,7 +408,7 @@ func (c *HTTP) GetProposal(proposalId int64) (types.Proposal, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !rawProposal.Response.IsOK(){
+	if !rawProposal.Response.IsOK() {
 		return nil, fmt.Errorf(rawProposal.Response.Log)
 	}
 	var proposal types.Proposal
@@ -693,6 +704,9 @@ func (c *HTTP) sign(m msg.Msg, options ...tx.Option) ([]byte, error) {
 		acc, err := c.GetAccount(fromAddr)
 		if err != nil {
 			return nil, err
+		}
+		if acc == nil {
+			return nil, fmt.Errorf("the signer account do not exist in the chain")
 		}
 		signMsg.Sequence = acc.GetSequence()
 		signMsg.AccountNumber = acc.GetAccountNumber()

--- a/common/types/fixed8.go
+++ b/common/types/fixed8.go
@@ -14,11 +14,13 @@ const (
 	precision = 8
 )
 
-// Fixed8Decimals represents 10^precision (100000000), a value of 1 in Fixed8 format
-var Fixed8Decimals = int(math.Pow10(precision))
-
-// Fixed8One represetns one unit
-var Fixed8One = NewFixed8(1)
+var (
+	// Fixed8Decimals represents 10^precision (100000000), a value of 1 in Fixed8 format
+	Fixed8Decimals = int(math.Pow10(precision))
+	// Fixed8One represetns one unit
+	Fixed8One  = NewFixed8(1)
+	Fixed8Zero = NewFixed8(0)
+)
 
 var errInvalidString = errors.New("Fixed8 must satisfy following regex \\d+(\\.\\d{1,8})?")
 

--- a/e2e/e2e_rpc_test.go
+++ b/e2e/e2e_rpc_test.go
@@ -416,6 +416,7 @@ func TestGetBalances(t *testing.T) {
 	acc, err := ctypes.AccAddressFromBech32(testAddress)
 	assert.NoError(t, err)
 	balances, err := c.GetBalances(acc)
+	assert.Equal(t,0,len(balances))
 	assert.NoError(t, err)
 	bz, err := json.Marshal(balances)
 	fmt.Println(string(bz))
@@ -448,6 +449,9 @@ func TestNoneExistGetBalance(t *testing.T) {
 	acc, _ := keys.NewKeyManager()
 	balance, err := c.GetBalance(acc.GetAddr(), "BNB")
 	assert.NoError(t, err)
+	assert.Equal(t,ctypes.Fixed8Zero,balance.Free)
+	assert.Equal(t,ctypes.Fixed8Zero,balance.Locked)
+	assert.Equal(t,ctypes.Fixed8Zero,balance.Frozen)
 	bz, err := json.Marshal(balance)
 	fmt.Println(string(bz))
 }

--- a/e2e/e2e_rpc_test.go
+++ b/e2e/e2e_rpc_test.go
@@ -399,7 +399,15 @@ func TestGetAccount(t *testing.T) {
 	bz, err := json.Marshal(account)
 	fmt.Println(string(bz))
 	fmt.Println(hex.EncodeToString(account.GetAddress().Bytes()))
+}
 
+func TestNoneExistGetAccount(t *testing.T) {
+	ctypes.Network = ctypes.TestNetwork
+	c := defaultClient()
+	acc, err := keys.NewKeyManager()
+	account, err := c.GetAccount(acc.GetAddr())
+	assert.NoError(t, err)
+	assert.Nil(t,account)
 }
 
 func TestGetBalances(t *testing.T) {
@@ -413,12 +421,32 @@ func TestGetBalances(t *testing.T) {
 	fmt.Println(string(bz))
 }
 
+func TestNoneExistGetBalances(t *testing.T) {
+	ctypes.Network = ctypes.TestNetwork
+	c := defaultClient()
+	acc, _ := keys.NewKeyManager()
+	balances, err := c.GetBalances(acc.GetAddr())
+	assert.NoError(t, err)
+	bz, err := json.Marshal(balances)
+	fmt.Println(string(bz))
+}
+
 func TestGetBalance(t *testing.T) {
 	ctypes.Network = ctypes.TestNetwork
 	c := defaultClient()
 	acc, err := ctypes.AccAddressFromBech32(testAddress)
 	assert.NoError(t, err)
 	balance, err := c.GetBalance(acc, "BNB")
+	assert.NoError(t, err)
+	bz, err := json.Marshal(balance)
+	fmt.Println(string(bz))
+}
+
+func TestNoneExistGetBalance(t *testing.T) {
+	ctypes.Network = ctypes.TestNetwork
+	c := defaultClient()
+	acc, _ := keys.NewKeyManager()
+	balance, err := c.GetBalance(acc.GetAddr(), "BNB")
 	assert.NoError(t, err)
 	bz, err := json.Marshal(balance)
 	fmt.Println(string(bz))


### PR DESCRIPTION
Resolve issue #105

**Solution**:
For a none exist account, in `GetBalance` and `GetBalances` RPC handler, will return empty response with no error.

Prepare release 1.2.2 after this PR